### PR TITLE
catkin for indigo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ roscpp
 rospy
 message_generation
 )
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 add_message_files(
@@ -26,7 +27,10 @@ add_service_files(
    SetActiveDMP.srv
  )
 
-generate_messages()
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 catkin_package(
 INCLUDE_DIRS include
@@ -40,5 +44,6 @@ include_directories(
 )
 
 add_library(dmp src/dmp.cpp src/fourier_approx.cpp src/radial_approx.cpp src/linear_approx.cpp)
+add_dependencies(dmp ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_executable(dmp_server nodes/dmp_server.cpp)
 target_link_libraries(dmp_server dmp ${catkin_LIBRARIES} ${Eigen_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>cmake_modules</build_depend>
   
   <run_depend>common_msgs</run_depend> <!-- nav_msgs, sensor_msgs, geometry_msgs -->
   <run_depend>image_common</run_depend>


### PR DESCRIPTION
didn't compile right away for me. Cmake_modules was added to include eigen, and a dependency on the message generation was added to the dmp library so that the messages would be generated before the library was compiled. 
